### PR TITLE
SmartAdServer image sync and noAd

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -132,7 +132,7 @@ export const spec = {
     const bidResponses = [];
     let response = serverResponse.body;
     try {
-      if (response) {
+      if (response && !response.isNoAd) {
         const bidRequest = JSON.parse(bidRequestString.data);
 
         let bidResponse = {
@@ -144,7 +144,8 @@ export const spec = {
           dealId: response.dealId,
           currency: response.currency,
           netRevenue: response.isNetCpm,
-          ttl: response.ttl
+          ttl: response.ttl,
+          dspPixels: response.dspPixels
         };
 
         if (bidRequest.mediaType === VIDEO) {
@@ -179,7 +180,15 @@ export const spec = {
         type: 'iframe',
         url: serverResponses[0].body.cSyncUrl
       });
-    }
+    } else if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body.dspPixels !== undefined)
+      {
+        serverResponses[0].body.dspPixels.forEach(function(pixel) {
+          syncs.push({
+            type: 'image',
+            url: pixel
+          });
+        });
+      }
     return syncs;
   }
 };

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -180,15 +180,14 @@ export const spec = {
         type: 'iframe',
         url: serverResponses[0].body.cSyncUrl
       });
-    } else if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body.dspPixels !== undefined)
-      {
-        serverResponses[0].body.dspPixels.forEach(function(pixel) {
-          syncs.push({
-            type: 'image',
-            url: pixel
-          });
+    } else if (syncOptions.pixelEnabled && serverResponses.length > 0 && serverResponses[0].body.dspPixels !== undefined) {
+      serverResponses[0].body.dspPixels.forEach(function(pixel) {
+        syncs.push({
+          type: 'image',
+          url: pixel
         });
-      }
+      });
+    }
     return syncs;
   }
 };

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -115,7 +115,41 @@ describe('Smart bid adapter tests', function () {
       ttl: 300,
       adUrl: 'http://awesome.fake.url',
       ad: '< --- awesome script --- >',
-      cSyncUrl: 'http://awesome.fake.csync.url'
+      cSyncUrl: 'http://awesome.fake.csync.url',
+      isNoAd: false
+    }
+  };
+
+  var BID_RESPONSE_IS_NO_AD = {
+    body: {
+      cpm: 12,
+      width: 300,
+      height: 250,
+      creativeId: 'zioeufg',
+      currency: 'GBP',
+      isNetCpm: true,
+      ttl: 300,
+      adUrl: 'http://awesome.fake.url',
+      ad: '< --- awesome script --- >',
+      cSyncUrl: 'http://awesome.fake.csync.url',
+      isNoAd: true
+    }
+  };
+
+  var BID_RESPONSE_IMAGE_SYNC = {
+    body: {
+      cpm: 12,
+      width: 300,
+      height: 250,
+      creativeId: 'zioeufg',
+      currency: 'GBP',
+      isNetCpm: true,
+      ttl: 300,
+      adUrl: 'http://awesome.fake.url',
+      ad: '< --- awesome script --- >',
+      cSyncUrl: 'http://awesome.fake.csync.url',
+      isNoAd: false,
+      dspPixels: ['pixelOne', 'pixelTwo', 'pixelThree']
     }
   };
 
@@ -147,6 +181,18 @@ describe('Smart bid adapter tests', function () {
     expect(requestContent).to.have.property('buid').and.to.equal('7569');
     expect(requestContent).to.have.property('appname').and.to.equal('Mozilla');
     expect(requestContent).to.have.property('ckid').and.to.equal(42);
+  });
+
+  it('Verify parse response with no ad', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS);
+    const bids = spec.interpretResponse(BID_RESPONSE_IS_NO_AD, request[0]);
+    expect(bids).to.have.lengthOf(0);
+
+    expect(function () {
+      spec.interpretResponse(BID_RESPONSE_IS_NO_AD, {
+        data: 'invalid Json'
+      })
+    }).to.not.throw();
   });
 
   it('Verify parse response', function () {
@@ -254,6 +300,27 @@ describe('Smart bid adapter tests', function () {
 
     syncs = spec.getUserSyncs({
       iframeEnabled: true
+    }, []);
+    expect(syncs).to.have.lengthOf(0);
+  });
+
+  it('Verifies user sync using dspPixels', function () {
+    var syncs = spec.getUserSyncs({
+      iframeEnabled: false,
+      pixelEnabled: true
+    }, [BID_RESPONSE_IMAGE_SYNC]);
+    expect(syncs).to.have.lengthOf(3);
+    expect(syncs[0].type).to.equal('image');
+
+    syncs = spec.getUserSyncs({
+      iframeEnabled: false,
+      pixelEnabled: false
+    }, [BID_RESPONSE_IMAGE_SYNC]);
+    expect(syncs).to.have.lengthOf(0);
+
+    syncs = spec.getUserSyncs({
+      iframeEnabled: false,
+      pixelEnabled: true
     }, []);
     expect(syncs).to.have.lengthOf(0);
   });


### PR DESCRIPTION
## Type of change
- [X] Feature: Sync changes/improvement

## Description of change
Change 1:

When the default iframe sync is not enabled we will now try to image sync if enabled.

if (iframe sync enabled)
{
     sync
}
else if (image sync enabled && sync urls provided)
{
     sync with each url
}

Change 2:
We need to handle noAds in our prebidResponse, in case of noad we don't want to build the bidresponse array.

Change 3:
Added tests to cover the first 2 changes.